### PR TITLE
Optimizations

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -259,7 +259,17 @@ fn weekdays() {
 }
 
 fn is_leap(year: i64) -> bool {
-    year % 4 == 0 && year % 100 != 0 || year % 400 == 0
+    // Leap year rules: years which are factors of 4, except those divisible
+    // by 100, unless they are divisible by 400.
+    //
+    // We test most common cases first: 4th year, 100th year, then 400th year.
+    //
+    // We factor out 4 from 100 since it was already tested, leaving us checking
+    // if it's divisible by 25. Afterwards, we do the same, factoring 25 from
+    // 400, leaving us with 16.
+    //
+    // Factors of 4 and 16 can quickly be found with bitwise AND.
+    year & 3 == 0 && (year % 25 != 0 || year & 15 == 0)
 }
 
 #[cfg(test)]

--- a/src/transitions.rs
+++ b/src/transitions.rs
@@ -237,7 +237,7 @@ impl FixedTimespanSetBuilder {
             let timespan = FixedTimespan {
                 utc_offset: timespan.offset,
                 dst_offset: *dst_offset,
-                name:       start_zone_id.clone().unwrap_or("".to_owned()),
+                name:       start_zone_id.clone().unwrap_or_else(String::new),
             };
 
             self.rest.push((time, timespan));
@@ -247,7 +247,7 @@ impl FixedTimespanSetBuilder {
             self.first = Some(FixedTimespan {
                 utc_offset: utc_offset,
                 dst_offset: *dst_offset,
-                name:       start_zone_id.clone().unwrap_or("".to_owned()),
+                name:       start_zone_id.clone().unwrap_or_else(String::new),
             });
         }
     }


### PR DESCRIPTION
The leap year checking and duplicate rule start calculations were found from profiling the `chrono-tz` build script. These bring the script's execution in debug mode (Cargo sadly doesn't run build.rs with optimizations ATM) from 4.88 to 3.50 seconds on my system when outputting to a tmpfs. With `--release` it is also lower.
  