### PR TITLE
Port docs and some other fixes

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -8,7 +8,9 @@ use parse_zoneinfo::table::TableBuilder;
 // ignored in this case, however this never happens in the tz database as it
 // stands.
 fn strip_comments(mut line: String) -> String {
-    line.find('#').map(|pos| line.truncate(pos));
+    if let Some(pos) = line.find('#') {
+        line.truncate(pos)
+    }
     line
 }
 
@@ -23,7 +25,7 @@ fn main() {
         let parser = LineParser::new();
         let mut builder = TableBuilder::new();
         for line in &lines {
-            match parser.parse_str(&line).unwrap() {
+            match parser.parse_str(line).unwrap() {
                 Line::Zone(zone) => builder.add_zone_line(zone).unwrap(),
                 Line::Continuation(cont) => builder.add_continuation_line(cont).unwrap(),
                 Line::Rule(rule) => builder.add_rule_line(rule).unwrap(),

--- a/parse-zoneinfo/Cargo.toml
+++ b/parse-zoneinfo/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "parse-zoneinfo"
 version = "0.3.0"
+edition = "2021"
+rust-version = "1.56.0"
 description = "Parse zoneinfo files from the IANA database"
 repository = "https://github.com/djzin/parse-zoneinfo"
 readme = "README.md"

--- a/parse-zoneinfo/src/lib.rs
+++ b/parse-zoneinfo/src/lib.rs
@@ -34,8 +34,6 @@
 #![warn(unreachable_pub)]
 #![warn(unused)]
 
-extern crate regex;
-
 pub mod line;
 pub mod structure;
 pub mod table;

--- a/parse-zoneinfo/src/line.rs
+++ b/parse-zoneinfo/src/line.rs
@@ -182,14 +182,14 @@ impl Default for LineParser {
             zone_line: Regex::new(
                 r##"(?x) ^
                 Zone \s+
-                ( ?P<name> [ A-Z a-z 0-9 / _ + - ]+ )  \s+
+                ( ?P<name> [A-Za-z0-9/_+-]+ )  \s+
                 ( ?P<gmtoff>     \S+ )  \s+
                 ( ?P<rulessave>  \S+ )  \s+
                 ( ?P<format>     \S+ )  \s*
-                ( ?P<year>       \S+ )? \s*
-                ( ?P<month>      \S+ )? \s*
-                ( ?P<day>        \S+ )? \s*
-                ( ?P<time>       \S+ )? \s*
+                ( ?P<year>       [0-9]+)? \s*
+                ( ?P<month>      [A-Za-z]+)? \s*
+                ( ?P<day>        [A-Za-z0-9><=]+ )? \s*
+                ( ?P<time>       [0-9:]+[suwz]? )? \s*
                 (\#.*)?
             $ "##,
             )
@@ -201,10 +201,10 @@ impl Default for LineParser {
                 ( ?P<gmtoff>     \S+ )  \s+
                 ( ?P<rulessave>  \S+ )  \s+
                 ( ?P<format>     \S+ )  \s*
-                ( ?P<year>       \S+ )? \s*
-                ( ?P<month>      \S+ )? \s*
-                ( ?P<day>        \S+ )? \s*
-                ( ?P<time>       \S+ )? \s*
+                ( ?P<year>       [0-9]+)? \s*
+                ( ?P<month>      [A-Za-z]+)? \s*
+                ( ?P<day>        [A-Za-z0-9><=]+ )? \s*
+                ( ?P<time>       [0-9:]+[suwz]? )? \s*
                 (\#.*)?
             $ "##,
             )

--- a/parse-zoneinfo/src/line.rs
+++ b/parse-zoneinfo/src/line.rs
@@ -73,6 +73,7 @@
 //! })));
 //! ```
 
+use std::fmt;
 use std::str::FromStr;
 // we still support rust that doesn't have the inherent methods
 #[allow(deprecated, unused_imports)]
@@ -106,6 +107,35 @@ pub enum Error {
     NotParsedAsZoneLine,
     NotParsedAsLinkLine,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::FailedYearParse(s) => write!(f, "failed to parse as a year value: \"{}\"", s),
+            Error::FailedMonthParse(s) => write!(f, "failed to parse as a month value: \"{}\"", s),
+            Error::FailedWeekdayParse(s) => {
+                write!(f, "failed to parse as a weekday value: \"{}\"", s)
+            }
+            Error::InvalidLineType(s) => write!(f, "line with invalid format: \"{}\"", s),
+            Error::TypeColumnContainedNonHyphen(s) => write!(
+                f,
+                "'type' column is not a hyphen but has the value: \"{}\"",
+                s
+            ),
+            Error::CouldNotParseSaving(s) => write!(f, "failed to parse RULES column: \"{}\"", s),
+            Error::InvalidDaySpec(s) => write!(f, "invalid day specification ('ON'): \"{}\"", s),
+            Error::InvalidTimeSpecAndType(s) => write!(f, "invalid time: \"{}\"", s),
+            Error::NonWallClockInTimeSpec(s) => {
+                write!(f, "time value not given as wall time: \"{}\"", s)
+            }
+            Error::NotParsedAsRuleLine => write!(f, "failed to parse line as a rule"),
+            Error::NotParsedAsZoneLine => write!(f, "failed to parse line as a zone"),
+            Error::NotParsedAsLinkLine => write!(f, "failed to parse line as a link"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 impl Default for LineParser {
     fn default() -> Self {

--- a/parse-zoneinfo/src/line.rs
+++ b/parse-zoneinfo/src/line.rs
@@ -18,7 +18,7 @@
 //! # fn main() {
 //! use parse_zoneinfo::line::*;
 //!
-//! let parser = LineParser::new();
+//! let parser = LineParser::default();
 //! let line = parser.parse_str("Rule  EU  1977    1980    -   Apr Sun>=1   1:00u  1:00    S");
 //!
 //! assert_eq!(line, Ok(Line::Rule(Rule {
@@ -40,7 +40,7 @@
 //! # fn main() {
 //! use parse_zoneinfo::line::*;
 //!
-//! let parser = LineParser::new();
+//! let parser = LineParser::default();
 //! let line = parser.parse_str("Zone  Australia/Adelaide  9:30  Aus  AC%sT  1971 Oct 31  2:00:00");
 //!
 //! assert_eq!(line, Ok(Line::Zone(Zone {
@@ -65,7 +65,7 @@
 //! ```
 //! use parse_zoneinfo::line::*;
 //!
-//! let parser = LineParser::new();
+//! let parser = LineParser::default();
 //! let line = parser.parse_str("Link  Europe/Istanbul  Asia/Istanbul");
 //! assert_eq!(line, Ok(Line::Link(Link {
 //!     existing:  "Europe/Istanbul",
@@ -107,8 +107,8 @@ pub enum Error {
     NotParsedAsLinkLine,
 }
 
-impl LineParser {
-    pub fn new() -> Self {
+impl Default for LineParser {
+    fn default() -> Self {
         LineParser {
             rule_line: Regex::new(
                 r##"(?x) ^
@@ -969,6 +969,11 @@ fn parse_time_type(c: &str) -> Option<TimeType> {
 }
 
 impl LineParser {
+    #[deprecated]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     fn parse_timespec_and_type(&self, input: &str) -> Result<TimeSpecAndType, Error> {
         if input == "-" {
             Ok(TimeSpecAndType(TimeSpec::Zero, TimeType::Wall))
@@ -1222,7 +1227,7 @@ mod tests {
         ($name:ident: $input:expr => $result:expr) => {
             #[test]
             fn $name() {
-                let parser = LineParser::new();
+                let parser = LineParser::default();
                 assert_eq!(parser.parse_str($input), $result);
             }
         };
@@ -1304,7 +1309,7 @@ mod tests {
     #[test]
     fn negative_offsets() {
         static LINE: &'static str = "Zone    Europe/London   -0:01:15 -  LMT 1847 Dec  1  0:00s";
-        let parser = LineParser::new();
+        let parser = LineParser::default();
         let zone = parser.parse_zone(LINE).unwrap();
         assert_eq!(
             zone.info.utc_offset,
@@ -1316,7 +1321,7 @@ mod tests {
     fn negative_offsets_2() {
         static LINE: &'static str =
             "Zone        Europe/Madrid   -0:14:44 -      LMT     1901 Jan  1  0:00s";
-        let parser = LineParser::new();
+        let parser = LineParser::default();
         let zone = parser.parse_zone(LINE).unwrap();
         assert_eq!(
             zone.info.utc_offset,
@@ -1327,7 +1332,7 @@ mod tests {
     #[test]
     fn negative_offsets_3() {
         static LINE: &'static str = "Zone America/Danmarkshavn -1:14:40 -    LMT 1916 Jul 28";
-        let parser = LineParser::new();
+        let parser = LineParser::default();
         let zone = parser.parse_zone(LINE).unwrap();
         assert_eq!(
             zone.info.utc_offset,

--- a/parse-zoneinfo/src/line.rs
+++ b/parse-zoneinfo/src/line.rs
@@ -1192,7 +1192,7 @@ impl LineParser {
         })
     }
 
-    pub fn parse_zone<'a>(&self, input: &'a str) -> Result<Zone<'a>, Error> {
+    fn parse_zone<'a>(&self, input: &'a str) -> Result<Zone<'a>, Error> {
         if let Some(caps) = self.zone_line.captures(input) {
             let name = caps.name("name").unwrap().as_str();
             let info = self.zoneinfo_from_captures(caps)?;
@@ -1202,7 +1202,7 @@ impl LineParser {
         }
     }
 
-    pub fn parse_link<'a>(&self, input: &'a str) -> Result<Link<'a>, Error> {
+    fn parse_link<'a>(&self, input: &'a str) -> Result<Link<'a>, Error> {
         if let Some(caps) = self.link_line.captures(input) {
             let target = caps.name("target").unwrap().as_str();
             let name = caps.name("name").unwrap().as_str();

--- a/parse-zoneinfo/src/line.rs
+++ b/parse-zoneinfo/src/line.rs
@@ -14,8 +14,6 @@
 //! Parsing a `Rule` line:
 //!
 //! ```
-//! # extern crate parse_zoneinfo;
-//! # fn main() {
 //! use parse_zoneinfo::line::*;
 //!
 //! let parser = LineParser::default();
@@ -31,13 +29,11 @@
 //!     time_to_add:  TimeSpec::HoursMinutes(1, 0),
 //!     letters:      Some("S"),
 //! })));
-//! # }
 //! ```
 //!
 //! Parsing a `Zone` line:
 //!
 //! ```
-//! # fn main() {
 //! use parse_zoneinfo::line::*;
 //!
 //! let parser = LineParser::default();
@@ -57,7 +53,6 @@
 //!                      ),
 //!     },
 //! })));
-//! # }
 //! ```
 //!
 //! Parsing a `Link` line:

--- a/parse-zoneinfo/src/structure.rs
+++ b/parse-zoneinfo/src/structure.rs
@@ -179,7 +179,7 @@ mod test {
         assert_eq!(
             structure.next(),
             Some(TableStructureEntry {
-                name: &"a".to_owned(),
+                name: "a",
                 children: vec![Child::TimeZone("b")]
             })
         );
@@ -197,14 +197,14 @@ mod test {
         assert_eq!(
             structure.next(),
             Some(TableStructureEntry {
-                name: &"a".to_owned(),
+                name: "a",
                 children: vec![Child::Submodule("b"), Child::TimeZone("e")]
             })
         );
         assert_eq!(
             structure.next(),
             Some(TableStructureEntry {
-                name: &"a/b".to_owned(),
+                name: "a/b",
                 children: vec![Child::TimeZone("c"), Child::TimeZone("d")]
             })
         );

--- a/parse-zoneinfo/src/structure.rs
+++ b/parse-zoneinfo/src/structure.rs
@@ -32,7 +32,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use table::Table;
+use crate::table::Table;
 
 /// Trait to put the `structure` method on Tables.
 pub trait Structure {
@@ -150,7 +150,7 @@ pub enum Child<'table> {
 #[allow(unused_results)]
 mod test {
     use super::*;
-    use table::Table;
+    use crate::table::Table;
 
     #[test]
     fn empty() {

--- a/parse-zoneinfo/src/table.rs
+++ b/parse-zoneinfo/src/table.rs
@@ -17,21 +17,31 @@
 //! ## Example
 //!
 //! ```
-//! use parse_zoneinfo::line::{Zone, Link, LineParser};
+//! use parse_zoneinfo::line::{Zone, Line, LineParser, Link};
 //! use parse_zoneinfo::table::{TableBuilder};
 //!
-//! let parser = LineParser::new();
-//! let zone = parser.parse_zone("Zone  Pacific/Auckland  11:39:04  -  LMT  1868  Nov  2").unwrap();
-//! let link = parser.parse_link("Link  Pacific/Auckland  Antarctica/McMurdo").unwrap();
-//!
+//! let parser = LineParser::default();
 //! let mut builder = TableBuilder::new();
-//! builder.add_zone_line(zone).unwrap();
-//! builder.add_link_line(link).unwrap();
+//!
+//! let zone = "Zone  Pacific/Auckland  11:39:04  -  LMT  1868  Nov  2";
+//! let link = "Link  Pacific/Auckland  Antarctica/McMurdo";
+//!
+//! for line in [zone, link] {
+//!     match parser.parse_str(&line)? {
+//!         Line::Zone(zone) => builder.add_zone_line(zone).unwrap(),
+//!         Line::Continuation(cont) => builder.add_continuation_line(cont).unwrap(),
+//!         Line::Rule(rule) => builder.add_rule_line(rule).unwrap(),
+//!         Line::Link(link) => builder.add_link_line(link).unwrap(),
+//!         Line::Space => {}
+//!     }
+//! }
+//!
 //! let table = builder.build();
 //!
 //! assert!(table.get_zoneset("Pacific/Auckland").is_some());
 //! assert!(table.get_zoneset("Antarctica/McMurdo").is_some());
 //! assert!(table.get_zoneset("UTC").is_none());
+//! # Ok::<(), parse_zoneinfo::line::Error>(())
 //! ```
 
 use std::collections::hash_map::{Entry, HashMap};

--- a/parse-zoneinfo/src/table.rs
+++ b/parse-zoneinfo/src/table.rs
@@ -301,7 +301,7 @@ impl TableBuilder {
             }
         }
 
-        let zoneset: &mut _ = match self.table.zonesets.entry(zone_line.name.to_owned()) {
+        let zoneset = match self.table.zonesets.entry(zone_line.name.to_owned()) {
             Entry::Occupied(_) => return Err(Error::DuplicateZone),
             Entry::Vacant(e) => e.insert(Vec::new()),
         };
@@ -319,7 +319,7 @@ impl TableBuilder {
         &mut self,
         continuation_line: line::ZoneInfo,
     ) -> Result<(), Error> {
-        let zoneset: &mut _ = match self.current_zoneset_name {
+        let zoneset = match self.current_zoneset_name {
             Some(ref name) => self.table.zonesets.get_mut(name).unwrap(),
             None => return Err(Error::SurpriseContinuationLine),
         };

--- a/parse-zoneinfo/src/table.rs
+++ b/parse-zoneinfo/src/table.rs
@@ -38,9 +38,7 @@ use std::collections::hash_map::{Entry, HashMap};
 use std::error::Error as ErrorTrait;
 use std::fmt;
 
-use line::{self, ChangeTime, DaySpec, Month, Year};
-
-use crate::line::TimeType;
+use crate::line::{self, ChangeTime, DaySpec, Month, TimeType, Year};
 
 /// A **table** of all the data in one or more zoneinfo files.
 #[derive(PartialEq, Debug, Default)]
@@ -391,10 +389,5 @@ impl<'line> fmt::Display for Error<'line> {
 impl<'line> ErrorTrait for Error<'line> {
     fn description(&self) -> &str {
         "interpretation error"
-    }
-
-    #[allow(bare_trait_objects)] // remove when we require edition 2018
-    fn cause(&self) -> Option<&ErrorTrait> {
-        None
     }
 }

--- a/parse-zoneinfo/src/table.rs
+++ b/parse-zoneinfo/src/table.rs
@@ -35,7 +35,6 @@
 //! ```
 
 use std::collections::hash_map::{Entry, HashMap};
-use std::error::Error as ErrorTrait;
 use std::fmt;
 
 use crate::line::{self, ChangeTime, DaySpec, Month, TimeType, Year};
@@ -388,12 +387,18 @@ pub enum Error<'line> {
 
 impl<'line> fmt::Display for Error<'line> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        match self {
+            Error::SurpriseContinuationLine => write!(
+                f,
+                "continuation line follows line that isn't a zone definition line"
+            ),
+            Error::UnknownRuleset(_) => {
+                write!(f, "zone definition refers to a ruleset that isn't defined")
+            }
+            Error::DuplicateLink(_) => write!(f, "link line with name that already exists"),
+            Error::DuplicateZone => write!(f, "zone line with name that already exists"),
+        }
     }
 }
 
-impl<'line> ErrorTrait for Error<'line> {
-    fn description(&self) -> &str {
-        "interpretation error"
-    }
-}
+impl<'line> std::error::Error for Error<'line> {}

--- a/parse-zoneinfo/src/table.rs
+++ b/parse-zoneinfo/src/table.rs
@@ -61,7 +61,7 @@ impl Table {
             Some(&*self.zonesets[zone_name])
         } else if self.links.contains_key(zone_name) {
             let target = &self.links[zone_name];
-            Some(&*self.zonesets[&*target])
+            Some(&*self.zonesets[target])
         } else {
             None
         }
@@ -276,6 +276,12 @@ pub struct TableBuilder {
     current_zoneset_name: Option<String>,
 }
 
+impl Default for TableBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TableBuilder {
     /// Creates a new builder with an empty table.
     pub fn new() -> TableBuilder {
@@ -333,7 +339,7 @@ impl TableBuilder {
             .table
             .rulesets
             .entry(rule_line.name.to_owned())
-            .or_insert_with(Vec::new);
+            .or_default();
 
         ruleset.push(rule_line.into());
         self.current_zoneset_name = None;

--- a/parse-zoneinfo/src/transitions.rs
+++ b/parse-zoneinfo/src/transitions.rs
@@ -334,9 +334,9 @@ impl FixedTimespanSetBuilder {
 
                 if *insert_start_transition {
                     if earliest_at < self.start_time.unwrap() {
-                        replace(start_utc_offset, timespan.offset);
-                        replace(start_dst_offset, *dst_offset);
-                        replace(
+                        let _ = replace(start_utc_offset, timespan.offset);
+                        let _ = replace(start_dst_offset, *dst_offset);
+                        let _ = replace(
                             start_zone_id,
                             Some(
                                 timespan
@@ -350,7 +350,7 @@ impl FixedTimespanSetBuilder {
                     if start_zone_id.is_none()
                         && *start_utc_offset + *start_dst_offset == timespan.offset + *dst_offset
                     {
-                        replace(
+                        let _ = replace(
                             start_zone_id,
                             Some(
                                 timespan

--- a/parse-zoneinfo/src/transitions.rs
+++ b/parse-zoneinfo/src/transitions.rs
@@ -197,10 +197,10 @@ impl TableTransitions for Table {
                 }
 
                 Saving::Multiple(ref rules) => {
-                    let rules = &self.rulesets[&*rules];
+                    let rules = &self.rulesets[rules];
                     builder.add_multiple_saving(
                         zone_info,
-                        &*rules,
+                        rules,
                         &mut dst_offset,
                         use_until,
                         utc_offset,
@@ -262,21 +262,22 @@ impl FixedTimespanSetBuilder {
             let timespan = FixedTimespan {
                 utc_offset: timespan.offset,
                 dst_offset: *dst_offset,
-                name: start_zone_id.clone().unwrap_or_else(String::new),
+                name: start_zone_id.clone().unwrap_or_default(),
             };
 
             self.rest.push((time, timespan));
             *insert_start_transition = false;
         } else {
             self.first = Some(FixedTimespan {
-                utc_offset: utc_offset,
+                utc_offset,
                 dst_offset: *dst_offset,
-                name: start_zone_id.clone().unwrap_or_else(String::new),
+                name: start_zone_id.clone().unwrap_or_default(),
             });
         }
     }
 
     #[allow(unused_results)]
+    #[allow(clippy::too_many_arguments)]
     fn add_multiple_saving(
         &mut self,
         timespan: &ZoneInfo,
@@ -391,7 +392,7 @@ impl FixedTimespanSetBuilder {
         };
 
         let mut zoneset = FixedTimespanSet {
-            first: first,
+            first,
             rest: self.rest,
         };
         optimise(&mut zoneset);

--- a/parse-zoneinfo/src/transitions.rs
+++ b/parse-zoneinfo/src/transitions.rs
@@ -101,7 +101,7 @@
 //! The logic in this file is based off of `zic.c`, which comes with the
 //! zoneinfo files and is in the public domain.
 
-use table::{RuleInfo, Saving, Table, ZoneInfo};
+use crate::table::{RuleInfo, Saving, Table, ZoneInfo};
 
 /// A set of timespans, separated by the instances at which the timespans
 /// change over. There will always be one more timespan than transitions.

--- a/tests/transition_tests.rs
+++ b/tests/transition_tests.rs
@@ -801,7 +801,7 @@ fn tripoli() {
 
 #[test]
 fn dushanbe() {
-    static ZONEINFO: &'static str = r#"
+    static ZONEINFO: &str = r#"
 Zone    Asia/Dushanbe   4:35:12 -   LMT 1924 May  2
             5:00    1:00    +05/+06 1991 Sep  9  2:00s
 "#;


### PR DESCRIPTION
This ports the documentation and two simple commits from zoneinfo-parse.
I also included a few commits to fix rust and clippy warnings and to update to rust 2021.